### PR TITLE
Better abort and lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,15 @@ Additionally components will have access to properties that has been set using `
 ## Client API
 The custom router context `RedialContext` makes it easy to add support for redial on the client side using the `render` property from `Router` in React Router. It provides the following properties as a way to configure how the data loading should behave.
 ```
-locals            Extra locals that should be provided to the hooks other than the default ones
-blocking          Hooks that should be completed before a route transition is completed
-defer             Hooks that are not needed before making a route transition
-parallel          If set to true the deferred hooks will run in parallel with the blocking ones
-initialLoading    Component should be shown on initial client load, useful if server rendering is not used
+locals                Extra locals that should be provided to the hooks other than the default ones
+blocking              Hooks that should be completed before a route transition is completed
+defer                 Hooks that are not needed before making a route transition
+parallel              If set to true the deferred hooks will run in parallel with the blocking ones
+initialLoading        Component should be shown on initial client load, useful if server rendering is not used
+onStarted(force)      Invoked when a route transition has been detected and when redial hooks will be invoked
+onError(error)        Invoked when an error happens, can be either a location change, manually aborted or other reason
+onAborted             Invoked if it was prematurely aborted through manual interaction
+onCompleted           Invoked if everything was completed successfully, both blocking and deferred
 ```
 
 ```js

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ force             If the provideHooks has been invoked using the reload function
 params            Route params from React Router
 location          Location object from React Router
 routeProps        Custom defined properties that has been defined on the route components
+isAborted         Function that returns if the hooks has been aborted, can be used to ignore the result
 ```
 
 ### Default props available to decorated components
@@ -68,6 +69,7 @@ routeProps        Custom defined properties that has been defined on the route c
 loading           Will be true when blocking hooks are not yet completed
 deferredLoading   Will be true when deferred hooks are not yet completed
 reload            Function that can be invoked to re-trigger the hooks for the current component
+abort             Function that can be invoked to abort current running hooks
 ```
 Additionally components will have access to properties that has been set using `setProps`.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ defer                 Hooks that are not needed before making a route transition
 parallel              If set to true the deferred hooks will run in parallel with the blocking ones
 initialLoading        Component should be shown on initial client load, useful if server rendering is not used
 onStarted(force)      Invoked when a route transition has been detected and when redial hooks will be invoked
-onError(error)        Invoked when an error happens, can be either a location change, manually aborted or other reason
+onError(error, type)  Invoked when an error happens, type can be either a "location-change", "aborted" or "other" reason
 onAborted             Invoked if it was prematurely aborted through manual interaction
 onCompleted           Invoked if everything was completed successfully, both blocking and deferred
 ```

--- a/examples/redux/components/App.js
+++ b/examples/redux/components/App.js
@@ -11,6 +11,7 @@ export default class App extends Component {
 
     return (
       <div style={style}>
+        <button onClick={this.props.abort}>Abort</button>
         <h1>React Router Redial Example</h1>
         <ul>
           <li>

--- a/examples/redux/components/Index.js
+++ b/examples/redux/components/Index.js
@@ -2,14 +2,20 @@ import React, { Component } from 'react';
 import { provideHooks } from 'redial';
 
 @provideHooks({
-  fetch: ({ setProps, getProps, force }) => new Promise((resolve) => {
+  fetch: ({ setProps, getProps, force, isAborted }) => new Promise((resolve) => {
     const { color } = getProps();
     if(!color || force) {
       setTimeout(() => {
+        if (isAborted()) {
+          console.log('We should ignore this');
+          return resolve();
+        } else {
+          console.log('Completed fine')
+        }
         const getValue = () => Math.round(Math.random() * 255);
         setProps({color: `rgb(${getValue()}, ${getValue()}, ${getValue()})`});
         resolve();
-      }, 1000);
+      }, 2000);
     } else {
       resolve();
     }

--- a/examples/redux/components/Index.js
+++ b/examples/redux/components/Index.js
@@ -20,7 +20,9 @@ import { provideHooks } from 'redial';
       // Will be available as this.props.data on the component
       setProps({ data: 'Client data' })
     }
-  }
+  },
+  deferDone: () => console.log('deferDone'),
+  blockingDone: () => console.log('blockingDone'),
 })
 export default class Index extends Component {
   render() {

--- a/examples/redux/render/client.js
+++ b/examples/redux/render/client.js
@@ -21,8 +21,8 @@ export default (container, routes, store) => {
         <RedialContext
           { ...props }
           locals={locals}
-          blocking={['fetch']}
-          defer={['defer', 'done']}
+          blocking={['fetch', 'blockingDone']}
+          defer={['defer', 'deferDone']}
           parallel={false}
           initialLoading={() => <div>Loading…</div>}
         />

--- a/src/RedialContext.js
+++ b/src/RedialContext.js
@@ -159,7 +159,7 @@ export default class RedialContext extends Component {
         });
 
         // Start deferred if we are not in parallel
-        if (!this.props.parallel) {
+        if (!force && !this.props.parallel) {
           this.runDeferred(
             this.props.defer,
             components,

--- a/src/RedialContext.js
+++ b/src/RedialContext.js
@@ -53,9 +53,9 @@ export default class RedialContext extends Component {
       return <RouterContext { ...props } createElement={createElement} />;
     },
 
-    onError(err) {
+    onError(err, type) {
       if (process.env.NODE_ENV !== 'production') {
-        console.error(err);
+        console.error(type, err);
       }
     },
 
@@ -158,9 +158,9 @@ export default class RedialContext extends Component {
 
     const bail = () => {
       if (aborted()) {
-        return 'Manually aborted';
+        return 'aborted';
       } else if (this.props.location !== props.location) {
-        return 'Location changed';
+        return 'location-changed';
       }
 
       return false;
@@ -197,7 +197,7 @@ export default class RedialContext extends Component {
 
     Promise.all(promises)
       .then(this.props.onCompleted)
-      .catch(this.props.onError);
+      .catch((err) => this.props.onError(err, bail() || 'other'));
   }
 
   runDeferred(hooks, components, props, force = false, bail) {

--- a/src/RedialContext.js
+++ b/src/RedialContext.js
@@ -137,6 +137,7 @@ export default class RedialContext extends Component {
       redialMap: this.state.redialMap,
       locals: this.props.locals,
       force,
+      bail: () => this.props.location !== props.location,
     }).then(({ redialMap }) => {
       this.setState({
         deferredLoading: false,
@@ -180,6 +181,7 @@ export default class RedialContext extends Component {
       redialMap: this.state.redialMap,
       locals: this.props.locals,
       force,
+      bail: () => this.props.location !== props.location,
     }).then(({ redialMap }) => {
       completeRouteTransition(redialMap);
     }).catch((err) => {

--- a/src/RedialContext.js
+++ b/src/RedialContext.js
@@ -36,6 +36,9 @@ export default class RedialContext extends Component {
     defer: React.PropTypes.array,
     parallel: React.PropTypes.bool,
     initialLoading: React.PropTypes.func,
+    onAborted: React.PropTypes.func,
+    onStarted: React.PropTypes.func,
+    onCompleted: React.PropTypes.func,
 
     // Server
     redialMap: React.PropTypes.object,
@@ -52,7 +55,25 @@ export default class RedialContext extends Component {
 
     onError(err) {
       if (process.env.NODE_ENV !== 'production') {
-        console.error('There was an error when fetching data: ', err);
+        console.error(err);
+      }
+    },
+
+    onAborted() {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('Loading was aborted manually');
+      }
+    },
+
+    onStarted(force) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.info('Loading started. Force:', force);
+      }
+    },
+
+    onCompleted() {
+      if (process.env.NODE_ENV !== 'production') {
+        console.info('Loading completed');
       }
     },
   };
@@ -66,6 +87,8 @@ export default class RedialContext extends Component {
     this.state = {
       loading: false,
       deferredLoading: false,
+      aborted: () => false,
+      abort: () => {},
       prevProps: null,
       redialMap: props.redialMap || hydrate(props),
       initial: props.blocking.length > 0,
@@ -81,6 +104,9 @@ export default class RedialContext extends Component {
         redialMap,
         reloadComponent: (component) => {
           this.reloadComponent(component);
+        },
+        abortLoading: () => {
+          this.abort();
         },
       },
     };
@@ -106,51 +132,99 @@ export default class RedialContext extends Component {
     this.load(component, this.props, true);
   }
 
-  load(components, props, force = false) {
-    this.runBlocking(
-      this.props.blocking,
-      components,
-      props,
-      force
-    );
+  abort() {
+    // We need to be in a loading state for it to make sense
+    // to abort something
+    if (this.state.loading || this.state.deferredLoading) {
+      this.state.abort();
 
-    if (force || this.props.parallel) {
-      this.runDeferred(
-        this.props.defer,
-        components,
-        props,
-        force
-      );
+      this.setState({
+        loading: false,
+        deferredLoading: false,
+      });
+
+      if (this.props.onAborted) {
+        this.props.onAborted();
+      }
     }
   }
 
-  runDeferred(hooks, components, props, force = false) {
+  load(components, props, force = false) {
+    let isAborted = false;
+    const abort = () => {
+      isAborted = true;
+    };
+    const aborted = () => isAborted;
+
+    const bail = () => {
+      if (aborted()) {
+        return 'Manually aborted';
+      } else if (this.props.location !== props.location) {
+        return 'Location changed';
+      }
+
+      return false;
+    };
+
+    if (this.props.onStarted) {
+      this.props.onStarted(force);
+    }
+
+    this.setState({
+      aborted,
+      abort,
+      loading: true,
+      prevProps: this.state.aborted() ? this.state.prevProps : this.props,
+    });
+
+    const promises = [this.runBlocking(
+      this.props.blocking,
+      components,
+      props,
+      force,
+      bail
+    )];
+
+    if (this.props.parallel) {
+      promises.push(this.runDeferred(
+        this.props.defer,
+        components,
+        props,
+        force,
+        bail
+      ));
+    }
+
+    Promise.all(promises)
+      .then(this.props.onCompleted)
+      .catch(this.props.onError);
+  }
+
+  runDeferred(hooks, components, props, force = false, bail) {
     // Get deferred data, will not block route transitions
     this.setState({
       deferredLoading: true,
     });
 
-    triggerHooks({
+    return triggerHooks({
       hooks,
       components,
       renderProps: props,
       redialMap: this.state.redialMap,
       locals: this.props.locals,
       force,
-      bail: () => this.props.location !== props.location,
+      bail,
     }).then(({ redialMap }) => {
       this.setState({
         deferredLoading: false,
         redialMap,
       });
-    }).catch(this.props.onError);
+    });
   }
 
-  runBlocking(hooks, components, props, force = false) {
+  runBlocking(hooks, components, props, force = false, bail) {
     const completeRouteTransition = (redialMap) => {
-      const sameLocation = this.props.location === props.location;
-
-      if (sameLocation && !this.unmounted) {
+      if (!bail() && !this.unmounted) {
         this.setState({
           loading: false,
           redialMap,
@@ -159,35 +233,31 @@ export default class RedialContext extends Component {
         });
 
         // Start deferred if we are not in parallel
-        if (!force && !this.props.parallel) {
-          this.runDeferred(
+        if (!this.props.parallel) {
+          return this.runDeferred(
             this.props.defer,
             components,
-            props
+            props,
+            force,
+            bail
           );
         }
       }
+
+      return Promise.resolve();
     };
 
-    this.setState({
-      loading: true,
-      prevProps: this.props,
-    });
-
-    triggerHooks({
+    return triggerHooks({
       hooks,
       components,
       renderProps: props,
       redialMap: this.state.redialMap,
       locals: this.props.locals,
       force,
-      bail: () => this.props.location !== props.location,
-    }).then(({ redialMap }) => {
-      completeRouteTransition(redialMap);
-    }).catch((err) => {
-      this.props.onError(err);
-      completeRouteTransition(this.state.redialMap);
-    });
+      bail,
+    }).then(({ redialMap }) =>
+      completeRouteTransition(redialMap)
+    );
   }
 
   render() {
@@ -195,7 +265,7 @@ export default class RedialContext extends Component {
       return this.props.initialLoading();
     }
 
-    const props = this.state.loading ? this.state.prevProps : this.props;
+    const props = this.state.loading || this.state.aborted() ? this.state.prevProps : this.props;
     return this.props.render(props);
   }
 }

--- a/src/RedialContextContainer.js
+++ b/src/RedialContextContainer.js
@@ -12,9 +12,16 @@ export default class RedialContextContainer extends React.Component {
 
   render() {
     const { Component, routerProps, ...props } = this.props;
-    const { loading, deferredLoading, reloadComponent, redialMap } = this.context.redialContext;
+    const {
+      abortLoading,
+      loading,
+      deferredLoading,
+      reloadComponent,
+      redialMap,
+    } = this.context.redialContext;
     const redialProps = redialMap.get(Component);
     const reload = () => reloadComponent(Component);
+    const abort = () => abortLoading();
     return (
       <Component
         { ...props }
@@ -23,6 +30,7 @@ export default class RedialContextContainer extends React.Component {
         loading={loading}
         deferredLoading={deferredLoading}
         reload={reload}
+        abort={abort}
       />
     );
   }

--- a/src/triggerHooks.js
+++ b/src/triggerHooks.js
@@ -5,7 +5,7 @@ import getRoutesProps from './getRoutesProps';
 import getLocals from './getLocals';
 
 export default function triggerHooks(
-  { hooks, components, locals, renderProps, force = false, redialMap = createMap() }
+  { hooks, components, locals, renderProps, force = false, bail, redialMap = createMap() }
 ) {
   // Set props for specific component
   const setProps = (component) =>
@@ -37,9 +37,12 @@ export default function triggerHooks(
 
   return hooks.reduce((promise, parallelHooks) =>
     promise.then(() =>
-      Promise.all(
-        [].concat(parallelHooks)
-          .map((hook) => trigger(hook, hookComponents, completeLocals))
+      (bail && bail() ?
+        Promise.resolve() :
+        Promise.all(
+          [].concat(parallelHooks)
+            .map((hook) => trigger(hook, hookComponents, completeLocals))
+        )
       )
     ), Promise.resolve()
   ).then(() => ({

--- a/src/triggerHooks.js
+++ b/src/triggerHooks.js
@@ -45,7 +45,7 @@ export default function triggerHooks({
   return hooks.reduce((promise, parallelHooks) =>
     promise.then(() => {
       if (bail()) {
-        throw new Error(bail());
+        throw new Error(`Redial was terminated because: ${bail()}`);
       }
       return Promise.all(
         [].concat(parallelHooks)
@@ -54,7 +54,7 @@ export default function triggerHooks({
     }), Promise.resolve()
   ).then(() => {
     if (bail()) {
-      throw new Error(bail());
+      throw new Error(`Redial was terminated because: ${bail()}`);
     }
 
     return {

--- a/src/triggerHooks.js
+++ b/src/triggerHooks.js
@@ -4,9 +4,15 @@ import createMap from './createMap';
 import getRoutesProps from './getRoutesProps';
 import getLocals from './getLocals';
 
-export default function triggerHooks(
-  { hooks, components, locals, renderProps, force = false, bail, redialMap = createMap() }
-) {
+export default function triggerHooks({
+  hooks,
+  components,
+  locals,
+  renderProps,
+  force = false,
+  bail = () => false,
+  redialMap = createMap(),
+}) {
   // Set props for specific component
   const setProps = (component) =>
     (props) => {
@@ -29,6 +35,7 @@ export default function triggerHooks(
     routeProps: getRoutesProps(renderProps.routes),
     setProps: setProps(component),
     getProps: getProps(component),
+    isAborted: bail,
     force,
     ...getLocals(component, locals),
   });
@@ -36,17 +43,23 @@ export default function triggerHooks(
   const hookComponents = components || renderProps.components;
 
   return hooks.reduce((promise, parallelHooks) =>
-    promise.then(() =>
-      (bail && bail() ?
-        Promise.resolve() :
-        Promise.all(
-          [].concat(parallelHooks)
-            .map((hook) => trigger(hook, hookComponents, completeLocals))
-        )
-      )
-    ), Promise.resolve()
-  ).then(() => ({
-    redialMap,
-    redialProps: redialMap.dehydrate([].concat(hookComponents)),
-  }));
+    promise.then(() => {
+      if (bail()) {
+        throw new Error(bail());
+      }
+      return Promise.all(
+        [].concat(parallelHooks)
+          .map((hook) => trigger(hook, hookComponents, completeLocals))
+      );
+    }), Promise.resolve()
+  ).then(() => {
+    if (bail()) {
+      throw new Error(bail());
+    }
+
+    return {
+      redialMap,
+      redialProps: redialMap.dehydrate([].concat(hookComponents)),
+    };
+  });
 }


### PR DESCRIPTION
This PR brings better support for aborting redial hooks, both manually and when location has been changed. It also adds some lifecycle functions that can be used on the client side.

We are also with this PR no longer running the hooks any differently when we using `force` or not. This means that we now respect `parallel` always.
