### PR TITLE
Add support to named components

### DIFF
--- a/src/getAllComponents.js
+++ b/src/getAllComponents.js
@@ -1,0 +1,12 @@
+export default function getAllComponents(components) {
+  const arr = Array.isArray(components) ? components : [components];
+  const result = [];
+  arr.forEach(component => {
+    if (typeof component === 'object') {
+      Object.keys(component).forEach(key => result.push(component[key]));
+    } else {
+      result.push(component);
+    }
+  });
+  return result;
+}

--- a/src/triggerHooks.js
+++ b/src/triggerHooks.js
@@ -3,6 +3,7 @@ import isPlainObject from 'lodash.isplainobject';
 import createMap from './createMap';
 import getRoutesProps from './getRoutesProps';
 import getLocals from './getLocals';
+import getAllComponents from './getAllComponents';
 
 export default function triggerHooks({
   hooks,
@@ -40,7 +41,7 @@ export default function triggerHooks({
     ...getLocals(component, locals),
   });
 
-  const hookComponents = components || renderProps.components;
+  const hookComponents = getAllComponents(components || renderProps.components);
 
   return hooks.reduce((promise, parallelHooks) =>
     promise.then(() => {

--- a/tests/getAllComponents.test.js
+++ b/tests/getAllComponents.test.js
@@ -1,0 +1,37 @@
+import expect from 'expect';
+import React from 'react';
+import { Route, IndexRoute, match } from 'react-router';
+
+import getAllComponents from '../src/getAllComponents';
+
+describe('getAllComponents', () => {
+  it('should return the correct length of route components', () => {
+    const MockComponent = () => (
+      <div></div>
+    );
+    const MockNamed1Component = () => (
+      <div></div>
+    );
+    const MockNamed2Component = () => (
+      <div></div>
+    );
+
+    const routes = (
+      <Route path="/" component={MockComponent} myprop={'top'}>
+        <IndexRoute component={MockComponent} myprop={'index'} />
+        <Route
+          path="user"
+          components={{ name1: MockNamed1Component, named2: MockNamed2Component }}
+        />
+      </Route>
+    );
+
+    match({ routes, location: '/' }, (error, redirectLocation, renderProps) => {
+      expect(getAllComponents(renderProps.components).length).toEqual(2);
+    });
+
+    match({ routes, location: '/user' }, (error, redirectLocation, renderProps) => {
+      expect(getAllComponents(renderProps.components).length).toEqual(3);
+    });
+  });
+});


### PR DESCRIPTION
Thank you for your awesome work! 
I noticed that the current react-router-redial doesn't support [named components](https://github.com/reactjs/react-router/blob/master/docs/API.md#named-components) while [async-props supports](https://github.com/ryanflorence/async-props/blob/master/modules/AsyncProps.js#L8), so I created this PR.

Best regards!
