### PR TITLE
Make sure afterTransitionLoading is set correctly

### DIFF
--- a/src/RedialContainer.js
+++ b/src/RedialContainer.js
@@ -18,7 +18,7 @@ export default class RedialContainer extends Component {
     const {
       abortLoading,
       loading,
-      deferredLoading,
+      afterTransitionLoading,
       reloadComponent,
       redialMap,
     } = this.context.redialContext;
@@ -34,7 +34,7 @@ export default class RedialContainer extends Component {
         ...redialProps,
         ...routerProps,
         loading,
-        deferredLoading,
+        afterTransitionLoading,
         reload,
         abort,
       }


### PR DESCRIPTION
This fixes a regression most likely introduced in https://github.com/dlmr/react-router-redial/pull/7/commits/5c6f4a46250ab4f094bfe9c4daf71014cd7a702b

Without this change checks on `afterTransitionLoading` will always be `undefined`.
