### PR TITLE
Fixes a bug in the default onError handler where type was undefined

### DIFF
--- a/src/RedialContext.js
+++ b/src/RedialContext.js
@@ -47,8 +47,9 @@ export default class RedialContext extends Component {
     afterTransition: [],
     parallel: false,
 
-    onError(err, { type }) {
+    onError(err, { beforeTransition }) {
       if (process.env.NODE_ENV !== 'production') {
+        const type = beforeTransition ? 'beforeTransition' : 'afterTransition';
         console.error(type, err);
       }
     },


### PR DESCRIPTION
Fixes a problem in the default `onError` handler where the type would always be undefined since it was not a valid property in the `metaData` object.